### PR TITLE
Proxy url

### DIFF
--- a/src/GooglePlacesTextInput.js
+++ b/src/GooglePlacesTextInput.js
@@ -69,12 +69,15 @@ const styles = StyleSheet.create({
   },
 });
 
+const DEFAULT_GOOGLE_API_URL =
+  'https://places.googleapis.com/v1/places:autocomplete';
 const GooglePlacesTextInput = forwardRef(
   (
     {
       apiKey,
       value,
       placeHolderText,
+      proxyUrl,
       languageCode,
       includedRegionCodes,
       types = [],
@@ -136,22 +139,20 @@ const GooglePlacesTextInput = forwardRef(
 
       try {
         setLoading(true);
-        const response = await fetch(
-          'https://places.googleapis.com/v1/places:autocomplete',
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-Goog-Api-Key': apiKey,
-            },
-            body: JSON.stringify({
-              input: processedText,
-              languageCode,
-              ...(includedRegionCodes?.length > 0 && { includedRegionCodes }),
-              ...(types.length > 0 && { includedPrimaryTypes: types }),
-            }),
-          }
-        );
+        const API_URL = proxyUrl ? proxyUrl : DEFAULT_GOOGLE_API_URL;
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Goog-Api-Key': apiKey,
+          },
+          body: JSON.stringify({
+            input: processedText,
+            languageCode,
+            ...(includedRegionCodes?.length > 0 && { includedRegionCodes }),
+            ...(types.length > 0 && { includedPrimaryTypes: types }),
+          }),
+        });
 
         const data = await response.json();
 

--- a/src/GooglePlacesTextInput.js
+++ b/src/GooglePlacesTextInput.js
@@ -140,12 +140,15 @@ const GooglePlacesTextInput = forwardRef(
       try {
         setLoading(true);
         const API_URL = proxyUrl ? proxyUrl : DEFAULT_GOOGLE_API_URL;
+        const headers = {
+          'Content-Type': 'application/json',
+        };
+        if (apiKey || apiKey != '') {
+          headers['X-Goog-Api-Key'] = apiKey;
+        }
         const response = await fetch(API_URL, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Goog-Api-Key': apiKey,
-          },
+          headers,
           body: JSON.stringify({
             input: processedText,
             languageCode,


### PR DESCRIPTION
proxyUrl added in props, for backend internal google apis usage purposes, like when project needs to hide API_KEY 


when proxyUrl provided, apiKey become useless, because of when proxy toa url, proxied site use envrionment own properties