### PR TITLE
feat: adding support for passing headers to proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ const PlaceDetailsExample = () => {
 | onBlur | (event: NativeSyntheticEvent<TextInputFocusEventData>) => void | No | - | Callback when input is blurred |
 | **Search Configuration** |
 | proxyUrl | string | No | - | Custom proxy URL for API requests (Required for Expo web) |
+| proxyHeaders | object | No | - | Headers to pass to the proxy (ex. { Authorization: 'Bearer AUTHTOKEN' } ) |
 | languageCode | string | No | - | Language code (e.g., 'en', 'fr') |
 | includedRegionCodes | string[] | No | - | Array of region codes to filter results |
 | types | string[] | No | [] | Array of place types to filter |
@@ -224,6 +225,7 @@ const PlaceDetailsExample = () => {
 | **Place Details Configuration** |
 | fetchDetails | boolean | No | false | Automatically fetch place details when a place is selected |
 | detailsProxyUrl | string | No | null | Custom proxy URL for place details requests (Required on Expo web)|
+| detailsProxyHeaders | object | No | - | Headers to pass to the place details proxy (ex. { Authorization: 'Bearer AUTHTOKEN' } ) |
 | detailsFields | string[] | No | ['displayName', 'formattedAddress', 'location', 'id'] | Array of fields to include in the place details response. see [Valid Fields](https://developers.google.com/maps/documentation/places/web-service/place-details#fieldmask) |
 | **UI Customization** |
 | showLoadingIndicator | boolean | No | true | Show loading spinner during API requests |

--- a/src/GooglePlacesTextInput.tsx
+++ b/src/GooglePlacesTextInput.tsx
@@ -100,6 +100,7 @@ interface GooglePlacesTextInputProps extends TextInputInheritedProps {
   value?: string;
   placeHolderText?: string;
   proxyUrl?: string;
+  proxyHeaders?: Record<string, string>;
   languageCode?: string;
   includedRegionCodes?: string[];
   types?: string[];
@@ -118,6 +119,7 @@ interface GooglePlacesTextInputProps extends TextInputInheritedProps {
   nestedScrollEnabled?: boolean;
   fetchDetails?: boolean;
   detailsProxyUrl?: string | null;
+  detailsProxyHeaders?: Record<string, string>;
   detailsFields?: string[];
   onError?: (error: any) => void;
   enableDebug?: boolean;
@@ -145,6 +147,7 @@ const GooglePlacesTextInput = forwardRef<
       value,
       placeHolderText,
       proxyUrl,
+      proxyHeaders = null,
       languageCode,
       includedRegionCodes,
       types = [],
@@ -163,6 +166,7 @@ const GooglePlacesTextInput = forwardRef<
       nestedScrollEnabled = true,
       fetchDetails = false,
       detailsProxyUrl = null,
+      detailsProxyHeaders = null,
       detailsFields = [],
       onError,
       enableDebug = false,
@@ -271,6 +275,7 @@ const GooglePlacesTextInput = forwardRef<
         text,
         apiKey: apiKey ? '[PROVIDED]' : '[MISSING]', // ✅ Security fix
         proxyUrl,
+        proxyHeaders,
         sessionToken,
         languageCode,
         includedRegionCodes,
@@ -294,6 +299,7 @@ const GooglePlacesTextInput = forwardRef<
           text,
           apiKey,
           proxyUrl,
+          proxyHeaders,
           sessionToken,
           languageCode,
           includedRegionCodes,
@@ -330,6 +336,7 @@ const GooglePlacesTextInput = forwardRef<
         placeId,
         apiKey: apiKey ? '[PROVIDED]' : '[MISSING]', // ✅ Security fix
         detailsProxyUrl,
+        detailsProxyHeaders,
         sessionToken,
         languageCode,
         detailsFields,

--- a/src/services/googlePlacesApi.ts
+++ b/src/services/googlePlacesApi.ts
@@ -6,6 +6,7 @@ interface FetchPredictionsParams {
   text: string;
   apiKey?: string;
   proxyUrl?: string;
+  proxyHeaders?: Record<string, string> | null;
   sessionToken?: string | null;
   languageCode?: string;
   includedRegionCodes?: string[];
@@ -17,6 +18,7 @@ interface FetchPlaceDetailsParams {
   placeId: string;
   apiKey?: string;
   detailsProxyUrl?: string | null;
+  detailsProxyHeaders?: Record<string, string> | null;
   sessionToken?: string | null;
   languageCode?: string;
   detailsFields?: string[];
@@ -39,6 +41,7 @@ export const fetchPredictions = async ({
   text,
   apiKey,
   proxyUrl,
+  proxyHeaders,
   sessionToken,
   languageCode,
   includedRegionCodes,
@@ -56,6 +59,12 @@ export const fetchPredictions = async ({
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
+
+    if (proxyUrl && proxyHeaders) {
+      Object.entries(proxyHeaders).forEach(([key, value]) => {
+        headers[key] = value;
+      });
+    }
 
     if (apiKey) {
       headers['X-Goog-Api-Key'] = apiKey;
@@ -96,6 +105,7 @@ export const fetchPlaceDetails = async ({
   placeId,
   apiKey,
   detailsProxyUrl,
+  detailsProxyHeaders,
   sessionToken,
   languageCode,
   detailsFields = [],
@@ -112,6 +122,12 @@ export const fetchPlaceDetails = async ({
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
+
+    if (detailsProxyUrl && detailsProxyHeaders) {
+      Object.entries(detailsProxyHeaders).forEach(([key, value]) => {
+        headers[key] = value;
+      });
+    }
 
     if (apiKey) {
       headers['X-Goog-Api-Key'] = apiKey;


### PR DESCRIPTION
Allows the passing of headers to our proxy so we can keep the Google Places API key secure on the server and pass an Authorization header so only authenticated users can make API calls.