### PR TITLE
fix: passing missing detailsProxyHeaders param when calling fetchPlaceDetailsApi

### DIFF
--- a/src/GooglePlacesTextInput.tsx
+++ b/src/GooglePlacesTextInput.tsx
@@ -366,6 +366,7 @@ const GooglePlacesTextInput = forwardRef<
         placeId,
         apiKey,
         detailsProxyUrl,
+        detailsProxyHeaders,
         sessionToken,
         languageCode,
         detailsFields,


### PR DESCRIPTION
Missed passing this in my last PR. 