### PR TITLE
Fix a bug to pass proxy headers

### DIFF
--- a/src/GooglePlacesTextInput.tsx
+++ b/src/GooglePlacesTextInput.tsx
@@ -366,6 +366,7 @@ const GooglePlacesTextInput = forwardRef<
         placeId,
         apiKey,
         detailsProxyUrl,
+        detailsProxyHeaders,
         sessionToken,
         languageCode,
         detailsFields,


### PR DESCRIPTION
Found a bug were the detailsProxyHeaders is missing where pass over the fetchDetails function