### PR TITLE
fix: add onpressin handler

### DIFF
--- a/src/GooglePlacesTextInput.tsx
+++ b/src/GooglePlacesTextInput.tsx
@@ -542,6 +542,9 @@ const GooglePlacesTextInput = forwardRef<
             { backgroundColor },
             style.suggestionItem,
           ]}
+          onPressIn={() => {
+            suggestionPressing.current = true;
+          }}
           onPress={() => {
             suggestionPressing.current = false;
             handleSuggestionPress(item);


### PR DESCRIPTION
Should fix: https://github.com/amitpdev/react-native-google-places-textinput/issues/37